### PR TITLE
Add new gradient computation backends

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -83,6 +83,36 @@ def K_M(x, z, M, L, power=1):
     pairwise_distances = np.clip(pairwise_distances, 0, np.inf)
     return np.exp(pairwise_distances * -(1.0 / L))
 
+def grad_laplace_mat_gpu(X, sol, L, P, power=1, batch_size=2, norm_control=False, **kwargs):
+    """
+    Gradient calculation done with einsum notation.
+
+    Parameters
+    ----------
+    X : np.ndarray, shape (n, d), all datapoints
+    sol : np.ndarray, shape (n, c), solution to the kernel system (alpha)
+    L : float, kernel width
+    P : np.ndarray, shape (d, d), metric matrix (M)
+    batch_size : int, number of batches to split the gradient into. Doesn't need to be used.
+    norm_control : bool, whether to perform norm control on the gradient.
+    """
+    raise NotImplementedError("Not implemented yet.")
+
+def grad_laplace_mat_opt(X, sol, L, P, batch_size=2, norm_control=False, **kwargs):
+    """
+    Optimized gradient calculation done with einsum notation.
+
+    Parameters
+    ----------
+    X : np.ndarray, shape (n, d), all datapoints
+    sol : np.ndarray, shape (n, c), solution to the kernel system (alpha)
+    L : float, kernel width
+    P : np.ndarray, shape (d, d), metric matrix (M)
+    batch_size : int, number of batches to split the gradient into. Doesn't need to be used.
+    norm_control : bool, whether to perform norm control on the gradient.
+    """
+    # example: M = np.einsum("mcd,mcD->dD", G, G)
+    raise NotImplementedError("Not implemented yet.")
 
 def grad_laplace_mat(X, sol, L, P, power=1, batch_size=2, norm_control=False):
     M = 0.0

--- a/test/test_rfm.py
+++ b/test/test_rfm.py
@@ -1,0 +1,65 @@
+"""
+Tests for RFM model
+"""
+import numpy as np
+from numpy.random import default_rng
+from src.rfm import RFM
+
+
+def test_create_rfm():
+    """
+    Test that we can create an RFM object
+    """
+    rfm = RFM()
+    assert rfm is not None
+
+def test_single_rfm():
+    """
+    Test that a basic RFM trains and gives predictable results.
+    """
+    rng = default_rng(seed=42)
+    # set up data
+    X = rng.normal(size=(100, 10))
+    y = (X[:, 0] + X[:, 1] + X[:, 2]).reshape(-1, 1)
+
+    # set up model
+    rfm = RFM()
+
+    # train model
+    rfm.fit(X, y)
+
+    # predict
+    y_hat = rfm.predict(X)
+
+    # check that the shapes are correct
+    assert y_hat.shape == y.shape
+    # mse should be 0.0018631536196526705 with seed=42
+    assert np.isclose(rfm.score(X, y), 0.0018631536196526705)
+
+def test_backends_equal():
+    """
+    Train two RFMs with different backends on the same data and check that the results are the same.
+    """
+    rng = default_rng(seed=42)
+    # set up data
+    X = rng.normal(size=(100, 10))
+    y = (X[:, 0] + X[:, 1] + X[:, 2]).reshape(-1, 1)
+
+    # set up models
+    rfm = RFM()
+    rfm2 = RFM(backend="opt")
+
+    # train models
+    rfm.fit(X, y)
+    rfm2.fit(X, y)
+
+    # predict
+    y_hat = rfm.predict(X)
+    y_hat2 = rfm2.predict(X)
+
+    # check that the shapes are correct
+    assert y_hat.shape == y.shape
+    assert y_hat2.shape == y.shape
+
+    # check that the predictions are the same
+    assert np.allclose(y_hat, y_hat2)


### PR DESCRIPTION
# What does this PR do?

Adds `backend` flag to RFM model with 3 options: "naive", "opt", and "gpu". Currently only "naive" is implemented, but `src/utils.py` has function stubs to implement the other two. As soon as those implementations are complete RFM should work with those new backends.

Tests are also added to ensure that as the new backends are developed, their results are identical to the naive implementation.

> Note: the "gpu" backend may require some work. Since we'll be using torch for this, kernel matrix computations will also have to use a new backend, so more changes will come in a later PR.

# How is this PR used?

When implementing the new backends, simply run

```shell
pytest
```

From the project root to test the model. Initially 2 should pass and 1 should fail with the `NotImplementedError`; however with a successful implementation all should pass.

# Any breaking changes?

1. Model parameters for RFM now have to be set at model creation (using `RFM()`) in order to bring model in-line with sklean standards.
2. `baseline` flag is deprecated in favor of `T=0` since they do the same thing.